### PR TITLE
feat: allow one-click links in assignment canvas

### DIFF
--- a/components/notes/BlockNoteEditor.tsx
+++ b/components/notes/BlockNoteEditor.tsx
@@ -49,8 +49,12 @@ export const BlockNoteEditor = ({
     onChange(content);
   }, [editor, onChange, readOnly]);
 
-  // Allow one-click link navigation even for plain pasted URLs or anchors
+  // Allow link navigation in readOnly mode, or when holding Cmd/Ctrl in editable mode
   const handleClickCapture = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!readOnly && !e.metaKey && !e.ctrlKey) {
+      return;
+    }
+
     // Ignore clicks on toolbars, popovers, menus, or interactive buttons
     if ((e.target as HTMLElement).closest('.bn-toolbar, .bn-popover, .bn-menu, .bn-side-menu, button, [role="button"]')) {
       return;
@@ -66,6 +70,8 @@ export const BlockNoteEditor = ({
     const link = (e.target as HTMLElement).closest('a');
     if (link && link.href) {
       if (link.href.startsWith('http://') || link.href.startsWith('https://') || link.href.startsWith('mailto:')) {
+        e.preventDefault();
+        e.stopPropagation();
         window.open(link.href, '_blank', 'noopener,noreferrer');
         return;
       }
@@ -107,6 +113,8 @@ export const BlockNoteEditor = ({
           if (url.toLowerCase().startsWith('www.')) {
             url = 'https://' + url;
           }
+          e.preventDefault();
+          e.stopPropagation();
           window.open(url, '_blank', 'noopener,noreferrer');
           return;
         }
@@ -118,11 +126,13 @@ export const BlockNoteEditor = ({
         if (url.toLowerCase().startsWith('www.')) {
           url = 'https://' + url;
         }
+        e.preventDefault();
+        e.stopPropagation();
         window.open(url, '_blank', 'noopener,noreferrer');
         return;
       }
     }
-  }, []);
+  }, [readOnly]);
 
   return (
     <div

--- a/components/notes/BlockNoteEditor.tsx
+++ b/components/notes/BlockNoteEditor.tsx
@@ -49,8 +49,84 @@ export const BlockNoteEditor = ({
     onChange(content);
   }, [editor, onChange, readOnly]);
 
+  // Allow one-click link navigation even for plain pasted URLs or anchors
+  const handleClickCapture = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // Ignore clicks on toolbars, popovers, menus, or interactive buttons
+    if ((e.target as HTMLElement).closest('.bn-toolbar, .bn-popover, .bn-menu, .bn-side-menu, button, [role="button"]')) {
+      return;
+    }
+
+    // Ignore if user has selected text (dragging to highlight or select)
+    const selection = window.getSelection();
+    if (selection && selection.toString().trim().length > 0) {
+      return;
+    }
+
+    // Check if clicked directly on an <a> element
+    const link = (e.target as HTMLElement).closest('a');
+    if (link && link.href) {
+      if (link.href.startsWith('http://') || link.href.startsWith('https://') || link.href.startsWith('mailto:')) {
+        window.open(link.href, '_blank', 'noopener,noreferrer');
+        return;
+      }
+    }
+
+    // Check if clicked on plain text containing a URL
+    let textNode: Node | null = null;
+    let offset = 0;
+
+    if (document.caretRangeFromPoint) {
+      const range = document.caretRangeFromPoint(e.clientX, e.clientY);
+      if (range && range.startContainer.nodeType === Node.TEXT_NODE) {
+        textNode = range.startContainer;
+        offset = range.startOffset;
+      }
+    } else if ((document as any).caretPositionFromPoint) {
+      const pos = (document as any).caretPositionFromPoint(e.clientX, e.clientY);
+      if (pos && pos.offsetNode.nodeType === Node.TEXT_NODE) {
+        textNode = pos.offsetNode;
+        offset = pos.offset;
+      }
+    }
+
+    if (textNode && textNode.textContent) {
+      const text = textNode.textContent;
+      const trimmed = text.trim();
+
+      // Regex to match URLs starting with http://, https://, or www.
+      const urlRegex = /(?:https?:\/\/|www\.)[^\s<]+[^<.,:;"')\]\s]/ig;
+      
+      let match;
+      while ((match = urlRegex.exec(text)) !== null) {
+        const start = match.index;
+        const end = start + match[0].length;
+        
+        // Check if click offset falls within this URL match
+        if (offset >= start && offset <= end) {
+          let url = match[0];
+          if (url.toLowerCase().startsWith('www.')) {
+            url = 'https://' + url;
+          }
+          window.open(url, '_blank', 'noopener,noreferrer');
+          return;
+        }
+      }
+
+      // Fallback: if the entire trimmed text node is just a URL
+      if (/^(?:https?:\/\/|www\.)[^\s]+$/i.test(trimmed)) {
+        let url = trimmed;
+        if (url.toLowerCase().startsWith('www.')) {
+          url = 'https://' + url;
+        }
+        window.open(url, '_blank', 'noopener,noreferrer');
+        return;
+      }
+    }
+  }, []);
+
   return (
     <div
+      onClickCapture={handleClickCapture}
       className={`
         notes-editor
         ${compact ? 'notes-editor--compact' : ''}

--- a/index.css
+++ b/index.css
@@ -159,6 +159,10 @@
   @apply rounded-lg;
 }
 
+.notes-editor a {
+  @apply text-primary underline cursor-pointer hover:opacity-80 transition-opacity font-medium;
+}
+
 .notes-editor .bn-container {
   @apply bg-transparent;
 }


### PR DESCRIPTION
## Summary
Allows one-click link navigation directly inside notes and assignment canvas editor blocks without requiring text selection or edit disruption.

## Changes
- **Link Click Handler**: Added a custom onClickCapture handler in BlockNoteEditor.tsx that detects clicks directly on <a> tags or plain text URLs (matching HTTP/HTTPS/mailto schemes) and opens them safely in a new tab.
- **Selection Safeguards**: Ignores clicks when selecting/highlighting text or interacting with menus and toolbars.
- **Styling**: Added .notes-editor a CSS styling in index.css with primary color, underline, and pointer cursor for clear visual affordance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Links inside notes can now be opened with a single click.
  * Plain text URLs in the editor are detected and opened in a new tab, including `http`, `https`, `mailto`, and `www` links.

* **Bug Fixes**
  * Clicks on editor controls, menus, buttons, and selected text no longer trigger link opening.
  * Link styling was added for clearer visibility and hover feedback inside notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->