### PR TITLE
fix: recursively strip undefined values from nested objects in assignment updates

### DIFF
--- a/context.tsx
+++ b/context.tsx
@@ -16,6 +16,7 @@ import {
 import { Assignment, AppContextType, Subject, User, PomodoroSession, PomodoroStats, PomodoroSessionType } from './types';
 import { DEFAULT_SUBJECT_COLOR } from './constants/colors';
 import { useSharedSpaces } from './hooks/useSharedSpaces';
+import { sanitizeForFirestore } from './utils/firestore';
 
 // ============================================================================
 // Types & Constants
@@ -432,52 +433,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   // =========================================================================
   // Helper Functions
   // =========================================================================
-
-  /**
-   * Deeply removes undefined values from an object to make it Firestore-compatible.
-   * Firestore does not accept undefined values; they must be omitted or set to null.
-   *
-   * This function recursively processes nested objects and arrays to ensure
-   * no undefined values exist at any level of the data structure.
-   *
-   * @param obj - The object to sanitize
-   * @returns A new object with all undefined values removed
-   */
-  const sanitizeForFirestore = <T extends Record<string, unknown>>(obj: T): Partial<T> => {
-    const sanitized: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(obj)) {
-      // Skip undefined values entirely
-      if (value === undefined) {
-        continue;
-      }
-
-      // Recursively sanitize nested objects
-      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-        const nestedSanitized = sanitizeForFirestore(value as Record<string, unknown>);
-        // Only include the nested object if it has properties after sanitization
-        if (Object.keys(nestedSanitized).length > 0) {
-          sanitized[key] = nestedSanitized;
-        }
-      }
-      // Recursively sanitize arrays
-      else if (Array.isArray(value)) {
-        sanitized[key] = value
-          .filter(item => item !== undefined)
-          .map(item =>
-            item !== null && typeof item === 'object' && !Array.isArray(item)
-              ? sanitizeForFirestore(item as Record<string, unknown>)
-              : item
-          );
-      }
-      // Include primitive values directly
-      else {
-        sanitized[key] = value;
-      }
-    }
-
-    return sanitized as Partial<T>;
-  };
 
   const addSubject = async (subject: Omit<Subject, 'id' | 'createdAt' | 'lastUpdated'>): Promise<void> => {
     if (!user?.uid) throw new Error('User not authenticated');

--- a/hooks/useSharedSpaces.ts
+++ b/hooks/useSharedSpaces.ts
@@ -35,6 +35,7 @@ import {
 } from '../types';
 import { prepareAssignmentUpdates } from '../utils/assignmentUpdate';
 import { buildShareLink, createSharedAssignmentId, parseSharedAssignmentId } from '../utils/sharedSpaces';
+import { sanitizeForFirestore } from '../utils/firestore';
 
 interface SharedSpaceDoc {
   activeInviteId?: string | null;
@@ -111,39 +112,6 @@ interface FirestoreErrorLike {
 
 const SHARED_BASE_FIELD_KEYS = ['title', 'dueDate', 'priority', 'examType'] as const;
 const SHARED_PERSONAL_FIELD_KEYS = ['status', 'reminder', 'notes', 'description'] as const;
-
-const sanitizeForFirestore = <T extends Record<string, unknown>>(obj: T): Partial<T> => {
-  const sanitized: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(obj)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      const nestedSanitized = sanitizeForFirestore(value as Record<string, unknown>);
-      if (Object.keys(nestedSanitized).length > 0) {
-        sanitized[key] = nestedSanitized;
-      }
-      continue;
-    }
-
-    if (Array.isArray(value)) {
-      sanitized[key] = value
-        .filter((item) => item !== undefined)
-        .map((item) => (
-          item !== null && typeof item === 'object' && !Array.isArray(item)
-            ? sanitizeForFirestore(item as Record<string, unknown>)
-            : item
-        ));
-      continue;
-    }
-
-    sanitized[key] = value;
-  }
-
-  return sanitized as Partial<T>;
-};
 
 const createSharedStateFromAssignment = (
   assignment: Pick<Assignment, 'description' | 'notes' | 'reminder' | 'status'>

--- a/server/sharedAssignments.ts
+++ b/server/sharedAssignments.ts
@@ -1,5 +1,6 @@
 import type admin from 'firebase-admin';
 import type { AssignmentDoc } from './telegram/types.js';
+import { sanitizeForFirestore } from '../utils/firestore.js';
 
 type Firestore = admin.firestore.Firestore;
 type DocumentReference = admin.firestore.DocumentReference;
@@ -109,39 +110,6 @@ const deleteRefsInBatches = async (
 
         await batch.commit();
     }
-};
-
-const sanitizeForFirestore = <T extends Record<string, unknown>>(obj: T): Partial<T> => {
-    const sanitized: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(obj)) {
-        if (value === undefined) {
-            continue;
-        }
-
-        if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-            const nestedSanitized = sanitizeForFirestore(value as Record<string, unknown>);
-            if (Object.keys(nestedSanitized).length > 0) {
-                sanitized[key] = nestedSanitized;
-            }
-            continue;
-        }
-
-        if (Array.isArray(value)) {
-            sanitized[key] = value
-                .filter((item) => item !== undefined)
-                .map((item) => (
-                    item !== null && typeof item === 'object' && !Array.isArray(item)
-                        ? sanitizeForFirestore(item as Record<string, unknown>)
-                        : item
-                ));
-            continue;
-        }
-
-        sanitized[key] = value;
-    }
-
-    return sanitized as Partial<T>;
 };
 
 const getParticipantIds = (

--- a/tests/unit/context/assignmentUpdateLogic.test.ts
+++ b/tests/unit/context/assignmentUpdateLogic.test.ts
@@ -64,4 +64,62 @@ describe('prepareAssignmentUpdates', () => {
     expect(result["reminder.preset"]).toBe(ReminderPreset.Custom);
     expect(result["reminder.customTime"]).toBe(deleteToken);
   });
+
+  it('strips undefined values from nested objects like notes', () => {
+    const updates: Partial<Assignment> = {
+      notes: {
+        version: 1,
+        blocks: [
+          { id: 'block-1', type: 'paragraph', content: undefined, styles: undefined },
+          { id: 'block-2', type: 'heading', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+      } as unknown as Assignment['notes'],
+    };
+
+    const result = prepareAssignmentUpdates(updates, createDeleteToken);
+
+    const notesResult = result.notes as Record<string, unknown>;
+    expect(notesResult.version).toBe(1);
+
+    const blocks = notesResult.blocks as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).not.toHaveProperty('content');
+    expect(blocks[0]).not.toHaveProperty('styles');
+    expect(blocks[0]).toHaveProperty('id', 'block-1');
+    expect(blocks[0]).toHaveProperty('type', 'paragraph');
+    expect(blocks[1]).toHaveProperty('content');
+  });
+
+  it('strips undefined values from nested arrays', () => {
+    const updates: Partial<Assignment> = {
+      notes: {
+        version: 1,
+        blocks: [
+          { id: 'block-1', type: 'paragraph', children: [undefined, { type: 'text' }] },
+        ],
+      } as unknown as Assignment['notes'],
+    };
+
+    const result = prepareAssignmentUpdates(updates, createDeleteToken);
+
+    const blocks = (result.notes as Record<string, unknown>).blocks as Array<Record<string, unknown>>;
+    const children = blocks[0]!.children as Array<unknown>;
+    expect(children).toHaveLength(1);
+    expect(children[0]).toEqual({ type: 'text' });
+  });
+
+  it('preserves null values in nested objects', () => {
+    const updates: Partial<Assignment> = {
+      subjectSnapshot: {
+        name: 'Math',
+        color: null as unknown as string,
+      } as unknown as Assignment['subjectSnapshot'],
+    };
+
+    const result = prepareAssignmentUpdates(updates, createDeleteToken);
+
+    const snapshot = result.subjectSnapshot as Record<string, unknown>;
+    expect(snapshot.name).toBe('Math');
+    expect(snapshot.color).toBeNull();
+  });
 });

--- a/utils/assignmentUpdate.ts
+++ b/utils/assignmentUpdate.ts
@@ -6,6 +6,35 @@ const shouldResetReminderSentAt = (updates: Partial<Assignment>): boolean => {
 };
 
 /**
+ * Recursively strips undefined values from nested objects and arrays.
+ * Preserves null and other primitive values.
+ */
+const stripUndefinedDeep = (value: unknown): unknown => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .filter((item) => item !== undefined)
+      .map((item) => stripUndefinedDeep(item));
+  }
+
+  const obj = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, val] of Object.entries(obj)) {
+    if (val === undefined) continue;
+    const stripped = stripUndefinedDeep(val);
+    if (stripped !== undefined) {
+      result[key] = stripped;
+    }
+  }
+
+  return result;
+};
+
+/**
  * Prepares assignment updates for Firestore by resetting reminder.sentAt where needed
  * and replacing undefined values with delete tokens.
  */
@@ -39,7 +68,13 @@ export const prepareAssignmentUpdates = <TDeleteToken>(
       continue;
     }
 
-    processedUpdates[key] = value === undefined ? createDeleteToken() : value;
+    if (value === undefined) {
+      processedUpdates[key] = createDeleteToken();
+    } else if (typeof value === 'object' && value !== null) {
+      processedUpdates[key] = stripUndefinedDeep(value);
+    } else {
+      processedUpdates[key] = value;
+    }
   }
 
   return processedUpdates;

--- a/utils/assignmentUpdate.ts
+++ b/utils/assignmentUpdate.ts
@@ -1,4 +1,5 @@
 import { Assignment } from '../types';
+import { isPlainObject } from './firestore';
 
 const shouldResetReminderSentAt = (updates: Partial<Assignment>): boolean => {
   return (updates.dueDate !== undefined || updates.reminder !== undefined) &&
@@ -7,10 +8,15 @@ const shouldResetReminderSentAt = (updates: Partial<Assignment>): boolean => {
 
 /**
  * Recursively strips undefined values from nested objects and arrays.
- * Preserves null and other primitive values.
+ * Preserves null, non-plain objects (Date, Timestamp, sentinels), and primitives.
  */
 const stripUndefinedDeep = (value: unknown): unknown => {
   if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  // Preserve non-plain objects (Date, Firestore Timestamp, sentinels, etc.)
+  if (!Array.isArray(value) && !isPlainObject(value)) {
     return value;
   }
 

--- a/utils/firestore.ts
+++ b/utils/firestore.ts
@@ -1,0 +1,66 @@
+/**
+ * Checks whether a value is a plain JavaScript object (i.e., an object
+ * whose prototype is `Object.prototype`).
+ *
+ * Returns `false` for class instances such as `Date`, Firestore `Timestamp`,
+ * `Map`, `Set`, and Firestore sentinel values (`deleteField()`,
+ * `serverTimestamp()`, etc.).
+ */
+export const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+/**
+ * Deeply removes `undefined` values from an object to make it Firestore-compatible.
+ * Firestore does not accept `undefined` values; they must be omitted or set to `null`.
+ *
+ * This function recursively processes nested plain objects and arrays to ensure
+ * no `undefined` values exist at any level of the data structure.
+ *
+ * Non-plain objects (e.g. `Date`, Firestore `Timestamp`, sentinels) are preserved
+ * as-is rather than being iterated.
+ *
+ * @param obj - The object to sanitize
+ * @returns A new object with all `undefined` values removed
+ */
+export const sanitizeForFirestore = <T extends Record<string, unknown>>(obj: T): Partial<T> => {
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    // Skip undefined values entirely
+    if (value === undefined) {
+      continue;
+    }
+
+    // Recursively sanitize nested plain objects
+    if (value !== null && isPlainObject(value)) {
+      const nestedSanitized = sanitizeForFirestore(value);
+      // Only include the nested object if it has properties after sanitization
+      if (Object.keys(nestedSanitized).length > 0) {
+        sanitized[key] = nestedSanitized;
+      }
+      continue;
+    }
+
+    // Recursively sanitize arrays
+    if (Array.isArray(value)) {
+      sanitized[key] = value
+        .filter((item) => item !== undefined)
+        .map((item) =>
+          item !== null && isPlainObject(item)
+            ? sanitizeForFirestore(item)
+            : item
+        );
+      continue;
+    }
+
+    // Include primitive values and non-plain objects directly
+    sanitized[key] = value;
+  }
+
+  return sanitized as Partial<T>;
+};


### PR DESCRIPTION
## Problem

Updating an assignment fails with `FirebaseError: Function updateDoc() called with invalid data. Unsupported field value: undefined` when the update payload contains nested objects with `undefined` values (e.g., BlockNote notes content).

## Root Cause

`prepareAssignmentUpdates` only replaced top-level `undefined` with `deleteField()` and handled the `reminder` object specially via dot notation. It did **not** recursively sanitize nested objects like `notes` (`NotesContent` with `Block[]`), so any `undefined` properties emitted by BlockNote blocks passed straight to `updateDoc` and caused Firestore to reject the write.

## Changes

- Added `stripUndefinedDeep` helper in `utils/assignmentUpdate.ts` to recursively remove `undefined` from nested objects and arrays while preserving `null` and primitives.
- Updated `prepareAssignmentUpdates` to use `stripUndefinedDeep` for all non-reminder object/array values.
- Added 3 new unit tests covering:
  - Nested object undefined stripping (notes blocks)
  - Nested array undefined filtering
  - Null preservation in nested objects

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested assignment updates by removing missing `undefined` values consistently across deeply nested objects and arrays.
  * Preserved explicit `null` values in nested fields so intentional empty values aren’t removed.
  * Continued correct behavior for top-level missing fields by treating them as removals.
* **Tests**
  * Added unit coverage to verify nested `undefined` cleanup and `null` preservation during assignment update preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->